### PR TITLE
fix: remove the leaving process after quit

### DIFF
--- a/packages/main/src/index.js
+++ b/packages/main/src/index.js
@@ -95,13 +95,12 @@ const createWindow = async () => {
       return;
     }
     e.preventDefault();
-    windowCloseHandler()
-      .then(() => {
-        app.quit();
-      })
+    windowCloseHandler(mainWindow)
       .catch((e) => {
         console.error(e);
-        app.exit(1);
+      })
+      .finally(() => {
+        mainWindow.close();
       });
     canClosed = true;
   });
@@ -131,8 +130,8 @@ app.on('NSApplicationDelegate.applicationSupportsSecureRestorableState', () => {
   return true;
 });
 
-async function windowCloseHandler() {
-  await SyncExportData();
+async function windowCloseHandler(win) {
+  await ipcMain.callRenderer(win, 'win:close');
 }
 
 app.on('second-instance', () => {
@@ -260,10 +259,6 @@ ipcMain.answerRenderer('storage:clear', (name) => store[name]?.clear());
 
 function addNoteFromMenu() {
   mainWindow.webContents.executeJavaScript('addNote();');
-}
-
-function SyncExportData() {
-  return ipcMain.callRenderer(mainWindow, 'app:sync');
 }
 
 function initializeMenu() {

--- a/packages/main/src/index.js
+++ b/packages/main/src/index.js
@@ -44,7 +44,7 @@ if (!isSingleInstance) {
 if (process.env.PORTABLE_EXECUTABLE_DIR)
   app.setPath(
     'userData',
-    path.join(process.env.PORTABLE_EXECUTABLE_DIR, 'data')
+    path.join(process.env.PORTABLE_EXECUTABLE_DIR, 'data'),
   );
 
 /**
@@ -89,6 +89,23 @@ const createWindow = async () => {
     }
   });
 
+  let canClosed = false;
+  mainWindow.on('close', (e) => {
+    if (canClosed) {
+      return;
+    }
+    e.preventDefault();
+    windowCloseHandler()
+      .then(() => {
+        app.quit();
+      })
+      .catch((e) => {
+        console.error(e);
+        app.exit(1);
+      });
+    canClosed = true;
+  });
+
   mainWindow?.webContents.setWindowOpenHandler(function (details) {
     const url = details.url;
     if (url.startsWith('note://')) return;
@@ -104,7 +121,7 @@ const createWindow = async () => {
       ? env.VITE_DEV_SERVER_URL
       : new URL(
           '../renderer/dist/index.html',
-          'file://' + __dirname
+          'file://' + __dirname,
         ).toString();
 
   await mainWindow.loadURL(pageUrl);
@@ -114,13 +131,9 @@ app.on('NSApplicationDelegate.applicationSupportsSecureRestorableState', () => {
   return true;
 });
 
-let beforeQuitListener = async (event) => {
-  console.log('Closing application');
-  event.preventDefault();
+async function windowCloseHandler() {
   await SyncExportData();
-};
-
-app.on('before-quit', beforeQuitListener);
+}
 
 app.on('second-instance', () => {
   if (mainWindow) {
@@ -192,36 +205,28 @@ ipcMain.answerRenderer('app:set-zoom', (newZoomLevel) => {
   mainWindow.webContents.zoomFactor = newZoomLevel;
 });
 
-ipcMain.answerRenderer('app:quitter', () => {
-  // Check if the listener is present before removing it
-  if (beforeQuitListener) {
-    app.removeListener('before-quit', beforeQuitListener);
-  }
-  app.quit();
-});
-
 ipcMain.answerRenderer('app:get-zoom', () => mainWindow.webContents.zoomFactor);
 
 ipcMain.answerRenderer('app:change-menu-visibility', (visibility, win) =>
-  win.setMenuBarVisibility(visibility)
+  win.setMenuBarVisibility(visibility),
 );
 
 ipcMain.answerRenderer('dialog:open', (props) => dialog.showOpenDialog(props));
 ipcMain.answerRenderer('dialog:message', (props) =>
-  dialog.showMessageBox(props)
+  dialog.showMessageBox(props),
 );
 ipcMain.answerRenderer('dialog:save', (props) => dialog.showSaveDialog(props));
 
 ipcMain.answerRenderer('fs:copy', ({ path, dest }) => copy(path, dest));
 ipcMain.answerRenderer('fs:output-json', ({ path, data }) =>
-  outputJson(path, data)
+  outputJson(path, data),
 );
 ipcMain.answerRenderer('fs:read-json', (path) => readJson(path));
 ipcMain.answerRenderer('fs:ensureDir', (path) => ensureDir(path));
 ipcMain.answerRenderer('fs:pathExists', (path) => pathExistsSync(path));
 ipcMain.answerRenderer('fs:remove', (path) => remove(path));
 ipcMain.answerRenderer('fs:writeFile', ({ path, data }) =>
-  writeFileSync(path, data)
+  writeFileSync(path, data),
 );
 ipcMain.answerRenderer('helper:relaunch', (options = {}) => {
   app.relaunch({
@@ -233,22 +238,22 @@ ipcMain.answerRenderer('helper:relaunch', (options = {}) => {
 ipcMain.answerRenderer('helper:get-path', (name) => app.getPath(name));
 ipcMain.answerRenderer(
   'helper:is-dark-theme',
-  () => nativeTheme.shouldUseDarkColors
+  () => nativeTheme.shouldUseDarkColors,
 );
 
 ipcMain.answerRenderer('storage:store', (name) => store[name]?.store);
 ipcMain.answerRenderer(
   'storage:replace',
-  ({ name, data }) => (store[name].store = data)
+  ({ name, data }) => (store[name].store = data),
 );
 ipcMain.answerRenderer('storage:get', ({ name, key, def }) =>
-  store[name]?.get(key, def)
+  store[name]?.get(key, def),
 );
 ipcMain.answerRenderer('storage:set', ({ name, key, value }) =>
-  store[name]?.set(key, value)
+  store[name]?.set(key, value),
 );
 ipcMain.answerRenderer('storage:delete', ({ name, key }) =>
-  store[name]?.delete(key)
+  store[name]?.delete(key),
 );
 ipcMain.answerRenderer('storage:has', ({ name, key }) => store[name]?.has(key));
 ipcMain.answerRenderer('storage:clear', (name) => store[name]?.clear());
@@ -258,7 +263,7 @@ function addNoteFromMenu() {
 }
 
 function SyncExportData() {
-  mainWindow.webContents.executeJavaScript('sync();');
+  return ipcMain.callRenderer(mainWindow, 'app:sync');
 }
 
 function initializeMenu() {
@@ -384,7 +389,7 @@ function initializeMenu() {
           click: async () => {
             const { shell } = require('electron');
             await shell.openExternal(
-              'https://danieles-organization.gitbook.io/beaver-notes'
+              'https://danieles-organization.gitbook.io/beaver-notes',
             );
           },
         },

--- a/packages/preload/src/index.js
+++ b/packages/preload/src/index.js
@@ -16,6 +16,12 @@ const apiKey = 'electron';
 function notification(props) {
   return ipcRenderer.callMain('app:notification', props);
 }
+ipcRenderer.answerMain('app:sync', async () => {
+  if (!window.sync) {
+    return;
+  }
+  await window.sync();
+});
 /**
  * @see https://github.com/electron/electron/issues/21437#issuecomment-573522360
  */

--- a/packages/preload/src/index.js
+++ b/packages/preload/src/index.js
@@ -16,11 +16,9 @@ const apiKey = 'electron';
 function notification(props) {
   return ipcRenderer.callMain('app:notification', props);
 }
-ipcRenderer.answerMain('app:sync', async () => {
-  if (!window.sync) {
-    return;
-  }
-  await window.sync();
+let closeFnList = [];
+ipcRenderer.answerMain('win:close', async () => {
+  await Promise.allSettled(closeFnList.map((fn) => fn()));
 });
 /**
  * @see https://github.com/electron/electron/issues/21437#issuecomment-573522360
@@ -32,6 +30,7 @@ const api = {
   notification,
   access: (dir) => access(dir, constants.R_OK | constants.W_OK),
   versions: process.versions,
+  addCloseFn: (fn) => closeFnList.every(f => f !== fn) && closeFnList.push(fn),
 };
 
 if (import.meta.env.MODE !== 'test') {

--- a/packages/renderer/src/components/app/AppSidebar.vue
+++ b/packages/renderer/src/components/app/AppSidebar.vue
@@ -427,10 +427,7 @@ export default {
 
       if (autoSync === 'true') {
         await syncexportData();
-        await ipcRenderer.callMain('app:quitter');
       }
-
-      await ipcRenderer.callMain('app:quitter');
     }
 
     async function syncimportData() {

--- a/packages/renderer/src/components/app/AppSidebar.vue
+++ b/packages/renderer/src/components/app/AppSidebar.vue
@@ -89,6 +89,7 @@ import { useDialog } from '@/composable/dialog';
 import { AES } from 'crypto-es/lib/aes';
 import { Utf8 } from 'crypto-es/lib/core';
 import dayjs from '@/lib/dayjs';
+import { onClose } from '../../composable/onClose';
 
 export default {
   setup() {
@@ -418,9 +419,7 @@ export default {
       }
     }
 
-    if (typeof window !== 'undefined') {
-      window.sync = exportAndQuit;
-    }
+    onClose(exportAndQuit);
 
     async function exportAndQuit() {
       const autoSync = localStorage.getItem('autoSync');

--- a/packages/renderer/src/composable/onClose.js
+++ b/packages/renderer/src/composable/onClose.js
@@ -1,0 +1,3 @@
+export const onClose = (fn) => {
+  window && window.electron.addCloseFn(fn);
+};


### PR DESCRIPTION
When the auto sync fails, the application will leave a process, and you can't restart the application.

This PR will add a new hook to manage the window `close` event. Then all handlers can be executed, and all errors can't affect the close event.