### PR TITLE
perf: move unnecessary deps to devDeps

### DIFF
--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -11,7 +11,6 @@ const electronBuilderConfig = {
   },
   files: [
     'packages/**/dist/**',
-    '!node_modules/**/*',
   ],
   extraMetadata: {
     version: packageJSON.version,

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@vitejs/plugin-vue": "^5.0.2",
     "autoprefixer": "^10.3.1",
     "babel-eslint": "^10.1.0",
-    "cross-env": "^7.0.3",
     "dmg-builder": "^24.5.0",
     "electron": "28.1.1",
     "electron-builder": "^24.13.3",
@@ -53,9 +52,7 @@
     "postcss-nested": "^6.0.1",
     "sass": "^1.70.0",
     "spectron": "^15.0.0",
-    "vite": "^5.0.11"
-  },
-  "dependencies": {
+    "vite": "^5.0.11",
     "@benrbray/prosemirror-math": "^0.2.2",
     "@tailwindcss/typography": "^0.5.13",
     "@tiptap/extension-code": "^2.1.16",
@@ -88,7 +85,6 @@
     "electron-store": "^8.0.0",
     "electron-updater": "^6.1.1",
     "electron-window-state": "^5.0.3",
-    "express": "^4.19.2",
     "fs-extra": "^11.2.0",
     "highlight.js": "^11.9.0",
     "katex": "^0.13.0",
@@ -97,8 +93,6 @@
     "mousetrap": "^1.6.5",
     "nanoid": "^3.1.25",
     "pinia": "^2.0.0-rc.4",
-    "socket.io": "^4.7.5",
-    "socket.io-client": "^4.7.5",
     "tailwindcss": "^3.4.3",
     "terser": "^5.26.0",
     "tiny-emitter": "^2.1.0",
@@ -109,5 +103,11 @@
     "vue": "^3.4.6",
     "vue-mermaid-render": "^0.1.4",
     "vue-router": "^4.0.11"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "cross-env": "^7.0.3",
+    "socket.io": "^4.7.5",
+    "socket.io-client": "^4.7.5"
   }
 }

--- a/packages/main/src/server.js
+++ b/packages/main/src/server.js
@@ -1,14 +1,13 @@
 import {verify} from './token/middleware';
+import http from 'http';
 
 // backend/api.js
 const express = require('express');
-const http = require('http');
-const socketIo = require('socket.io');
+const socketIO = require('socket.io');
 const cors = require('cors');
-
 const app = express();
 const server = http.createServer(app);
-const io = socketIo(server, {
+const io = socketIO(server, {
   cors: {
     origin: 'http://localhost:5173',
     methods: ['GET', 'POST'],

--- a/packages/main/src/token/index.js
+++ b/packages/main/src/token/index.js
@@ -1,4 +1,4 @@
-const crypto = require('crypto');
+import crypto from 'crypto';
 
 /**
  * @typedef {object} ClientConfig

--- a/packages/main/vite.config.js
+++ b/packages/main/vite.config.js
@@ -4,6 +4,7 @@ import { builtinModules } from 'module';
 
 import {defineConfig} from 'vite';
 import {loadAndSetEnv} from '../../scripts/loadAndSetEnv.mjs';
+import packages from '../../package.json';
 
 const PACKAGE_ROOT = __dirname;
 
@@ -43,6 +44,7 @@ export default defineConfig({
     rollupOptions: {
       external: [
         'electron',
+        ...Object.keys(packages.dependencies),
         ...builtinModules,
       ],
       output: {

--- a/packages/preload/vite.config.js
+++ b/packages/preload/vite.config.js
@@ -3,6 +3,7 @@ import {join} from 'path';
 import { builtinModules } from 'module';
 import {defineConfig} from 'vite';
 import {loadAndSetEnv} from '../../scripts/loadAndSetEnv.mjs';
+import packages from '../../package.json';
 
 const PACKAGE_ROOT = __dirname;
 
@@ -42,6 +43,7 @@ export default defineConfig({
     rollupOptions: {
       external: [
         'electron',
+        ...Object.keys(packages.dependencies),
         ...builtinModules,
       ],
       output: {

--- a/packages/renderer/dist/index.html
+++ b/packages/renderer/dist/index.html
@@ -6,8 +6,8 @@
   <meta content="width=device-width, initial-scale=1.0" name="viewport">
   <meta name="referrer" content="no-referrer" />
   <title>Beaver Notes</title>
-  <script type="module" crossorigin src="./index-lKmr3bmI.js"></script>
-  <link rel="stylesheet" crossorigin href="./index-XC-oEqdp.css">
+  <script type="module" crossorigin src="./index-CGMF69U-.js"></script>
+  <link rel="stylesheet" crossorigin href="./index-Dyp6baKv.css">
 </head>
 <body>
 <div id="app" class="dark:border-gray-700"></div>


### PR DESCRIPTION
@Daniele-rolli I made some packaging changes you need to know. I referred to the packaging method of [electron-vite](https://github.com/electron-vite/electron-vite-vue) and moved unnecessary dependencies to `devDependencies`. This will ensure that `electron-builder` only packages required dependencies into `node_modules` instead of removing `node_modules` totally.

This may affect the way you install dependencies. In most cases, you only need to install dependencies to `devDependencies`, unless you can only use `require` in the main and preload processes.