### PR TITLE
🧪 New translation utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ types/env.d.ts
 *.log
 
 .env
+.env.private
 .eslintcache
 
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider

--- a/env.js
+++ b/env.js
@@ -5,5 +5,9 @@ import { dirname } from 'path';
 // Resolve current directory path
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+export function loadEnv(env) {
+  dotenv.config({ path: `${__dirname}/.env.${env}` });
+}
+
 // Load .env.development file
-dotenv.config({ path: `${__dirname}/.env.development` });
+loadEnv('development');

--- a/scripts/translationUtil.js
+++ b/scripts/translationUtil.js
@@ -1,7 +1,5 @@
-#!/bin/node
 import path from 'node:path';
 import fs from 'node:fs';
-import readline from 'node:readline';
 
 const targetLng = process.argv.slice(-1)[0];
 const __dirname = new URL('.', import.meta.url).pathname;
@@ -11,36 +9,36 @@ if (targetLng === process.argv[1]) {
   process.exit(1);
 }
 
-function writeData(tips, path, data) {
-  const rl = readline.createInterface(process.stdin, process.stdout);
-  return new Promise((resolve) => {
-    rl.question(tips, (anwser) => {
-      if (anwser.toLocaleLowerCase()[0] === 'y') {
-        fs.writeFileSync(path, JSON.stringify(data, null, 2));
-        console.log('Writed!');
-      }
-      rl.close();
-      resolve();
-    });
-  });
+function highlightText(text) {
+  return `\x1b[33m${text}\x1b[0m`; // Yellow color
 }
 
-async function diffTranslation(localePath) {
+async function showUnsynchronized(localePath) {
   const enPath = path.resolve(__dirname, `${localePath}/en.json`);
   const targetPath = path.resolve(__dirname, `${localePath}/${targetLng}.json`);
-  const enTranslation = JSON.parse(fs.readFileSync(enPath).toString());
-  if (!fs.existsSync(targetPath)) {
-    await writeData(`No such translation for ${targetLng}.\nCan you generate it on \x1b[31m${targetPath}\x1b[0m from English?y/[n]`, targetPath, enTranslation);
+  
+  if (!fs.existsSync(enPath)) {
+    console.log(`\n${highlightText('Error:')} English translation file (${enPath}) not found.`);
     return;
   }
+
+  if (!fs.existsSync(targetPath)) {
+    console.log(`\n${highlightText(`No translation found for ${targetLng}`)}.`);
+    console.log(`Run ${highlightText('yarn run update-tran')} to update.`);
+    return;
+  }
+
+  const enTranslation = JSON.parse(fs.readFileSync(enPath).toString());
   const targetTranslation = JSON.parse(fs.readFileSync(targetPath).toString());
-  const [obj, diffObj] = diffObject(enTranslation, targetTranslation);
+  
+  const [ diffObj] = diffObject(enTranslation, targetTranslation);
+  
   if (Object.keys(diffObj).length > 0) {
-    console.log('diff translation in ' + targetPath + ' is');
+    console.log(`\n${highlightText(`Unsynchronized translations for ${targetLng}:`)}`);
     console.log(diffObj);
-    await writeData(`Overwrite ${targetLng}?y/[n]`, targetPath, Object.assign(targetTranslation, obj));
+    console.log(`Run ${highlightText('yarn run update-tran')} to update.`);
   } else {
-    console.log('no diff in ' + targetPath);
+    console.log(`\nTranslations for ${targetLng} are synchronized.`);
   }
 }
 
@@ -69,4 +67,4 @@ function diffObject(source, target) {
   return [obj, diffObj];
 }
 
-await diffTranslation('../packages/renderer/src/pages/settings/locales');
+showUnsynchronized('../packages/renderer/src/pages/settings/locales');

--- a/scripts/updateTranslations.js
+++ b/scripts/updateTranslations.js
@@ -1,15 +1,16 @@
 #!/bin/node
-import '../env.js';
+import { loadEnv } from '../env.js';
 
 import fs from 'node:fs';
 import path from 'node:path';
 import fetch from 'node-fetch';
 import readline from 'node:readline';
 
+loadEnv('private');
 const API_BASE_URL = 'https://translate-beaver.duckdns.org/api/v1';
-const PROJECT_ID = process.env.PROJECT_ID;
-const CLIENT_ID = process.env.CLIENT_ID;
-const CLIENT_SECRET = process.env.CLIENT_SECRET;
+const PROJECT_ID = process.env.PROJECT_ID.trim();
+const CLIENT_ID = process.env.CLIENT_ID.trim();
+const CLIENT_SECRET = process.env.CLIENT_SECRET.trim();
 const LOCALES_DIR = './packages/renderer/src/pages/settings/locales';
 
 async function getAuthToken() {
@@ -99,7 +100,12 @@ function askUserForLanguage(translations) {
     });
     console.log(`${translations.length + 1}. Download all languages`);
 
-    rl.question('Please select a language by number: ', (answer) => {
+    rl.question('Please select a language by number or type q to quit: ', (answer) => {
+      if (answer === 'q') {
+        rl.close();
+        console.log('quit');
+        return;
+      }
       const index = parseInt(answer, 10) - 1;
       if (index === translations.length) {
         resolve('all');

--- a/scripts/updateTranslations.js
+++ b/scripts/updateTranslations.js
@@ -1,0 +1,143 @@
+#!/bin/node
+import '../env.js';
+
+import fs from 'node:fs';
+import path from 'node:path';
+import fetch from 'node-fetch';
+import readline from 'node:readline';
+
+const API_BASE_URL = 'https://translate-beaver.duckdns.org/api/v1';
+const PROJECT_ID = process.env.PROJECT_ID;
+const CLIENT_ID = process.env.CLIENT_ID;
+const CLIENT_SECRET = process.env.CLIENT_SECRET;
+const LOCALES_DIR = './packages/renderer/src/pages/settings/locales';
+
+async function getAuthToken() {
+  const response = await fetch(`${API_BASE_URL}/auth/token`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      grant_type: 'client_credentials',
+      client_id: CLIENT_ID,
+      client_secret: CLIENT_SECRET,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to obtain auth token');
+  }
+
+  const data = await response.json();
+  return data.access_token;
+}
+
+async function listTranslations(token) {
+  const response = await fetch(
+    `${API_BASE_URL}/projects/${PROJECT_ID}/translations`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error('Failed to list translations');
+  }
+
+  const data = await response.json();
+  return data.data;
+}
+
+async function downloadTranslation(token, localeCode) {
+  const response = await fetch(
+    `${API_BASE_URL}/projects/${PROJECT_ID}/exports?locale=${localeCode}&format=jsonnested`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to download translation for locale: ${localeCode}`);
+  }
+
+  const data = await response.json();
+  return data;
+}
+
+function saveTranslationFile(localeCode, data) {
+  const shortLocaleCode = localeCode.includes('_')
+    ? localeCode.split('_')[0]
+    : localeCode;
+  const filePath = path.join(LOCALES_DIR, `${shortLocaleCode}.json`);
+
+  if (!fs.existsSync(LOCALES_DIR)) {
+    fs.mkdirSync(LOCALES_DIR, { recursive: true });
+  }
+
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
+  console.log(
+    `Saved translation file for locale: ${shortLocaleCode} at ${filePath}`,
+  );
+}
+
+function askUserForLanguage(translations) {
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+
+    console.log('Available languages:');
+    translations.forEach((translation, index) => {
+      const { language, code } = translation.locale;
+      console.log(`${index + 1}. ${language} (${code})`);
+    });
+    console.log(`${translations.length + 1}. Download all languages`);
+
+    rl.question('Please select a language by number: ', (answer) => {
+      const index = parseInt(answer, 10) - 1;
+      if (index === translations.length) {
+        resolve('all');
+      } else if (index >= 0 && index < translations.length) {
+        resolve(translations[index].locale.code);
+      } else {
+        console.log('Invalid selection. Exiting.');
+        process.exit(1);
+      }
+      rl.close();
+    });
+  });
+}
+
+async function main() {
+  try {
+    const token = await getAuthToken();
+    console.log('Auth token obtained successfully.');
+    const translations = await listTranslations(token);
+    console.log('Translations listed successfully.');
+
+    const selectedLocale = await askUserForLanguage(translations);
+    if (selectedLocale === 'all') {
+      for (const translation of translations) {
+        const { code } = translation.locale;
+        const translationData = await downloadTranslation(token, code);
+        saveTranslationFile(code, translationData);
+      }
+      console.log('All translations downloaded and saved successfully.');
+    } else {
+      const translation = await downloadTranslation(token, selectedLocale);
+      console.log('Translation downloaded successfully.');
+      saveTranslationFile(selectedLocale, translation);
+      console.log('Translation downloaded and saved successfully.');
+    }
+  } catch (error) {
+    console.error('Error:', error.message);
+  }
+}
+
+main();


### PR DESCRIPTION
I've modified [translationUtil.js](https://github.com/Beaver-Notes/Beaver-Notes/compare/development...Utils?expand=1#diff-4daa036164031823bcacb446d97553e11530b294477ccd0f3b45f9d8d27ada52) so that it no longer overwrites the file with the en.json content. Instead, it prompts the maintainer to run the new [updateTranslations.js](https://github.com/Beaver-Notes/Beaver-Notes/compare/development...Utils?expand=1#diff-846a1599f4c5a5536fe130732a24438a73d7e9e0851ea4d35dff0bacc4b6064c) script. This script, when provided with the `PROJECT_ID, CLIENT_ID, and CLIENT_SECRET` stored in `.env.development` from the **Traduora API**, allows the user to **list available translations and download them either individually or in bulk** to the `../packages/renderer/src/pages/settings/locales` directory. This improvement should enhance our workflow. 

These scripts are not perfect but they are something already. Please review them and share your thoughts. If you need the credentials, you can obtain them from the Traduora platform. I've already ensured that your role has been changed to admin so you can access the API. 

Here's what you should add to the .env.development

```env
PROJECT_ID=250b3536-bfe5-4b8c-b336-d425bf928490 #already public
CLIENT_ID=your CLIENT_ID
CLIENT_SECRET= your CLIENT_SECRET
```