### PR TITLE
perf: move the textarea to the top

### DIFF
--- a/packages/renderer/src/lib/tiptap/exts/math-block/MathBlock.vue
+++ b/packages/renderer/src/lib/tiptap/exts/math-block/MathBlock.vue
@@ -1,9 +1,5 @@
 <template>
   <node-view-wrapper>
-    <p
-      ref="contentRef"
-      :class="{ 'dark:text-purple-400 text-purple-500': selected }"
-    ></p>
     <div v-if="selected" class="bg-input transition rounded-lg p-2">
       <div class="flex mb-2">
         <textarea
@@ -43,6 +39,10 @@
         />
       </div>
     </div>
+    <p
+      ref="contentRef"
+      :class="{ 'dark:text-purple-400 text-purple-500': selected }"
+    ></p>
   </node-view-wrapper>
 </template>
 <script>

--- a/packages/renderer/src/lib/tiptap/exts/mermaid-block/MermaidBlock.vue
+++ b/packages/renderer/src/lib/tiptap/exts/mermaid-block/MermaidBlock.vue
@@ -1,11 +1,6 @@
 <template>
   <NodeViewWrapper>
     <div>
-      <MermaidComponent
-        :class="{ 'dark:text-purple-400 text-purple-500': selected }"
-        :content="mermaidContent"
-        @click="openTextarea"
-      />
       <div v-if="showTextarea" class="bg-input transition rounded-lg p-2">
         <textarea
           ref="inputRef"
@@ -17,12 +12,22 @@
           @keydown.ctrl.enter="closeTextarea"
           @keydown.exact="handleKeydown"
         ></textarea>
-        <div class="border-t-2 p-2">
+        <div class="border-t-2 p-2 flex justify-between">
           <p style="margin: 0">
             <strong>{{ translations._idvue.exit }}</strong>
           </p>
+          <v-remixicon
+            class="cursor-pointer"
+            name="riCloseLine"
+            @click="() => (showTextarea = false)"
+          />
         </div>
       </div>
+      <MermaidComponent
+        :class="{ 'dark:text-purple-400 text-purple-500': selected }"
+        :content="mermaidContent"
+        @click="openTextarea"
+      />
     </div>
   </NodeViewWrapper>
 </template>


### PR DESCRIPTION
1. add a close icon for the mermaid block.
2. move the `textarea` to the top.

Syntax errors are always triggered during editing, causing the `textarea` to move up and down. I moved the `textarea` to the top to reduce the impact.