### PR TITLE
Provide default value for Mac specific configuration entry

### DIFF
--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -49,7 +49,7 @@ const electronBuilderConfig = {
       'com.apple.security.device.audio-input': true,
     },
     notarize: {
-      teamId: process.env.APPLE_TEAM_ID,
+      teamId: process.env.APPLE_TEAM_ID || 'none',
     },
   },
   linux: {


### PR DESCRIPTION
## Pull Request Type
- [ ] **Feature/Component** (New feature or component)
- [ ] **Bug Fix** (Fixes an issue or bug)
- [X] **Minor Change** (Documentation, README updates, or small UI tweaks)

## Checklist (For Features/Bug Fixes)

- [ ] Does this PR address the **intended feature/bug** without any unintended changes?
- [ ] Have all **new components/features** been tested for functionality?
- [ ] Have all **bugs been fixed** and verified?
- [ ] Is the **UI/UX** consistent across different screen/window sizes?
- [ ] Have **translations** been updated for all new user-facing components?
- [ ] Have you confirmed that the **same work has been applied / will be applied to the mobile app** (if applicable)?
- [ ] Have **tests** been added or updated for new components/features?
- [ ] Is this PR ready for release, with appropriate versioning?

## Minor Changes (Documentation, Small UI Tweaks)
- [X] Does this PR include only **non-functional changes** (e.g., documentation, small UI tweaks)?
- [X] Are these changes **safe** and do not affect core app functionality?

## Description of Changes
**Briefly describe the changes introduced in this PR:**

Electron builder fails if the environment variable `APPLE_TEAM_ID` is not set. Since this value is not necessary for any other platform than Mac OS and to be able to build the app from source anytime, the configuration item should have a default value.

<details><summary>Error output of electron-builder</summary>

```
  • electron-builder  version=24.10.0 os=6.12.8-arch1-1
  • loaded configuration  file=/home/moabeat/aur/beaver-notes/src/Beaver-Notes-3.8.0/electron-builder.config.cjs
(node:156306) ExperimentalWarning: CommonJS module /home/moabeat/aur/beaver-notes/src/Beaver-Notes-3.8.0/electron-builder.config.cjs is loading ES Module /home/moabeat/aur/beaver-notes/src/Beaver-Notes-3.8.0/env.js using require().
Support for loading ES Module in require() is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
  ⨯ Invalid configuration object. electron-builder 24.10.0 has been initialized using a configuration object that does not match the API schema.
 - configuration.mac should be one of these:
   object { appId?, artifactName?, asar?, asarUnpack?, binaries?, bundleShortVersion?, bundleVersion?, category?, compression?, cscInstallerKeyPassword?, cscInstallerLink?, cscKeyPassword?, cscLink?, darkModeSupport?, defaultArch?, detectUpdateChannel?, electronLanguages?, electronUpdaterCompatibility?, entitlements?, entitlementsInherit?, entitlementsLoginHelper?, executableName?, extendInfo?, extraDistFiles?, extraFiles?, extraResources?, fileAssociations?, files?, forceCodeSigning?, gatekeeperAssess?, generateUpdatesFilesForAllChannels?, hardenedRuntime?, helperBundleId?, helperEHBundleId?, helperGPUBundleId?, helperNPBundleId?, helperPluginBundleId?, helperRendererBundleId?, icon?, identity?, mergeASARs?, minimumSystemVersion?, notarize?, preAutoEntitlements?, protocols?, provisioningProfile?, publish?, releaseInfo?, requirements?, signIgnore?, singleArchFiles?, strictVerify?, target?, timestamp?, type?, x64ArchFiles? } | null
   -> Options related to how build macOS targets.
   Details:
    * configuration.mac.notarize has an unknown property 'teamId'. These properties are valid:
      object { appBundleId?, ascProvider? }
    * configuration.mac.notarize misses the property 'teamId'. Should be:
      string
      -> The team ID you want to notarize under for when using `notarytool`
     How to fix:
     1. Open https://www.electron.build/configuration/mac
     2. Search the option name on the page (or type in into Search to find across the docs).
       * Not found? The option was deprecated or not exists (check spelling).
       * Found? Check that the option in the appropriate place. e.g. "title" only in the "dmg", not in the root.
```

</details> 

## Related Issues
**Link to related issues, bugs, or tasks:**

none

## Testing Steps
**Steps for reviewers to test the new feature or fix:**

1. Build the app from source on any platform that is not Mac OS

## Screenshots (if applicable)
**Add screenshots to illustrate changes or bug fixes:**

none