### PR TITLE
fix: use folder confirmation prompt when deleting a folder

### DIFF
--- a/src/components/home/HomeFolderCard.vue
+++ b/src/components/home/HomeFolderCard.vue
@@ -633,7 +633,7 @@ function selectColorIcon(color) {
 
 function deleteFolder() {
   dialog.confirm({
-    title: translations.value.card.confirmPrompt,
+    title: translations.value.card.confirmPromptFolder,
     onConfirm: () => {
       folderStore.delete(props.folder.id, { deleteContents: true });
     },


### PR DESCRIPTION
deleteFolder() referenced card.confirmPrompt ("delete this note?") instead of the existing card.confirmPromptFolder key, so the folder delete dialog showed the note wording.

### Pull Request Type

- [ ] **Feature(s)**
- [X] **Bug Fix(es)**
- [ ] **Minor Change(s)** (Docs/UI)

### Checklist

- [X] Does this PR solve the **issue(s)**? 
- [X] Has it been **tested**?
- [X] Is the UI **consistent**?
- [X] Are **translations** updated (if applicable)?
- [ ] Have the changes been ported to mobile (if not, we will handle it)?

### Description

Simple typo is fixed.

### Related Issues

[**Link to related issues/bugs:**](https://github.com/Beaver-Notes/Beaver-Notes/issues/431)
